### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
+To view code in GitHub preview, you need to add a Gemfile to your GitHub repository. Here is the Gemfile content you can add:
+You can create a file called Gemfile in your repository locally, and then add and commit this file to your remote repository on GitHub. After that, you will be able to view the Gemfile code in the GitHub preview
+
 source "https://rubygems.org"
 
 # Hello! This is where you manage which Jekyll version is used to run.


### PR DESCRIPTION
If you're having trouble viewing the contents of your Gemfile in GitHub preview, it may be that you need to correctly configure your repository for GitHub Pages or that GitHub isn't recognizing the Gemfile as part of a Jekyll site.

Here are some steps you can try to resolve this issue:

Make sure the Gemfile is in the root of your GitHub repository. Make sure your repository is configured correctly for GitHub Pages. You can do this by going to your repository settings on GitHub and ensuring that the GitHub Pages option is set to use the correct branch (usually main or master) and that the publish directory is set to root. If you are using a Jekyll theme, make sure the theme is correctly configured and included in your repository. Some themes require additional settings in the _config.yml file. Make sure GitHub correctly recognized your repository as a Jekyll site. You can check this by going to the "Settings" tab of your GitHub repository and checking if there is a message indicating that the site is being built with Jekyll. If after following these steps you are still unable to view the contents of your Gemfile in the GitHub preview, it may be helpful to contact GitHub support for further assistance. They can help you resolve any specific technical issues related to setting up GitHub Pages or recognizing your Jekyll site.